### PR TITLE
put bounds on the TELEX, 16N, and ER-301 commands for output numbers

### DIFF
--- a/src/ops/er301.c
+++ b/src/ops/er301.c
@@ -51,6 +51,9 @@ const tele_op_t op_SC_CV_OFF =
 void ERSend(uint8_t command, uint16_t output, int16_t value, bool set) {
     // zero-index the output
     output -= 1;
+    // return if out of range
+    if (output < 0 || output > 299)
+        return;
     // convert the output to the device and the port
     uint8_t port = output % 100;
     uint8_t device = output / 100;

--- a/src/ops/fader.c
+++ b/src/ops/fader.c
@@ -21,6 +21,9 @@ static void op_FADER_get(const void *NOTUSED(data), scene_state_t *ss,
     uint16_t input = cs_pop(cs);
     // zero-index the input
     input -= 1;
+    // return if out of range
+    if (input < 0 || input > 15)
+        return;
     // convert the input to the device and the port
     uint8_t port = input % 16;
     uint8_t device = input / 16;

--- a/src/ops/telex.c
+++ b/src/ops/telex.c
@@ -373,6 +373,9 @@ void TXSend(uint8_t model, uint8_t command, uint8_t output, int16_t value,
             bool set) {
     // zero-index the output
     output -= 1;
+    // return if out of range
+    if (output < 0 || output > 31)
+        return;
     // convert the output to the device and the port
     uint8_t port = output & 3;
     uint8_t device = output >> 2;
@@ -408,6 +411,9 @@ void ReceiveIt(uint8_t address, uint8_t port, command_state_t *cs) {
 void TXReceive(uint8_t model, command_state_t *cs, uint8_t mode, bool shift) {
     // zero-index the output
     uint8_t input = cs_pop(cs) - 1;
+    // return if out of range
+    if (input < 0 || input > 31)
+        return;
     // send the port, device and address
     uint8_t port = input & 3;
     uint8_t device = input >> 2;


### PR DESCRIPTION
changes:

* added bounds checks to output and input numbers so that calls that are out of the supported range do not execute code. Affects the TELEX, 16N, and ER-301 i2c operators.
