### PR TITLE
fixed failing test by ensuring that out of bounds i2c reads return zero

### DIFF
--- a/src/ops/fader.c
+++ b/src/ops/fader.c
@@ -22,8 +22,10 @@ static void op_FADER_get(const void *NOTUSED(data), scene_state_t *ss,
     // zero-index the input
     input -= 1;
     // return if out of range
-    if (input < 0 || input > 15)
+    if (input < 0 || input > 15) {
+        cs_push(cs, 0);
         return;
+    }
     // convert the input to the device and the port
     uint8_t port = input % 16;
     uint8_t device = input / 16;

--- a/src/ops/telex.c
+++ b/src/ops/telex.c
@@ -412,8 +412,11 @@ void TXReceive(uint8_t model, command_state_t *cs, uint8_t mode, bool shift) {
     // zero-index the output
     uint8_t input = cs_pop(cs) - 1;
     // return if out of range
-    if (input < 0 || input > 31)
+    if (input < 0 || input > 31) {
+        // need to put a zero on the stack for tests to pass
+        cs_push(cs, 0);
         return;
+    }
     // send the port, device and address
     uint8_t port = input & 3;
     uint8_t device = input >> 2;


### PR DESCRIPTION
My bad. Did the bounds fix so quickly that I didn't re-run my tests. They don't like it when a function that is to return a value elects not to in some circumstances. I don't either.

Fixed in this pull request. :)