### PR TITLE
Fixes for Pandoc >= 2, other doc changes

### DIFF
--- a/docs/ops/controlflow.toml
+++ b/docs/ops/controlflow.toml
@@ -159,6 +159,7 @@ short = "potentially execute command with probability `x` (0-100)"
 [SCRIPT]
 prototype = "SCRIPT"
 prototype_set = "SCRIPT x"
+aliases = ["$"]
 short = "get current script number, or execute script `x` (1-8), recursion allowed"
 description = """
 Execute script `x` (1-8), recursion allowed.

--- a/utils/cheatsheet.py
+++ b/utils/cheatsheet.py
@@ -19,9 +19,9 @@ TEMPLATE_DIR = ROOT_DIR / "utils" / "templates"
 DOCS_DIR = ROOT_DIR / "docs"
 OP_DOCS_DIR = DOCS_DIR / "ops"
 FONTS_DIR = ROOT_DIR / "utils" / "fonts"
-_VERSION_ = get_tt_version()
-_VERSION_STR_ = "Teletype " + \
-              _VERSION_["tag"] + " " + _VERSION_["hash"] + " Cheatsheet"
+TT_VERSION = get_tt_version()
+VERSION_STR = " ".join(["Teletype", TT_VERSION["tag"], TT_VERSION["hash"],
+                        "Documentation"])
 
 
 # We want to run inject_latex in parallel as it's quite slow, and we must run
@@ -82,11 +82,11 @@ def cheatsheet_tex():
     print(f"Using ops docs directory: {OP_DOCS_DIR}")
     print()
 
-    output = _VERSION_STR_ + "\n\n"
+    output = VERSION_STR + "\n\n"
     for (section, title, new_page) in OPS_SECTIONS:
         toml_file = Path(OP_DOCS_DIR, section + ".toml")
         if toml_file.exists() and toml_file.is_file():
-            output += f"\group{{{ title }}}\n\n"
+            output += f"\\group{{{ title }}}\n\n"
             print(f"Reading {toml_file}")
             # n.b. Python 3.6 dicts maintain insertion order
             ops = toml.loads(toml_file.read_text())
@@ -105,7 +105,7 @@ def cheatsheet_tex():
                 output += "\\end{op}"
                 output += "\n\n"
             if new_page:
-                output += "\pagebreak\n\n"
+                output += "\\pagebreak\n\n"
     return output
 
 

--- a/utils/cheatsheet.py
+++ b/utils/cheatsheet.py
@@ -71,9 +71,11 @@ OPS_SECTIONS = [
 
 def latex_safe(s):
     # backslash must be first, otherwise it will duplicate itself
-    unsafe = ["\\", "&", "%", "$", "#", "_", "{", "}", "~", "^"]
+    unsafe = ["\\", "&", "%", "$", "#", "_", "{", "}", "^"]
     for u in unsafe:
         s = s.replace(u, "\\" + u)
+    # ~ is special
+    s = s.replace("~", "\\~{}")
     return s
 
 

--- a/utils/cheatsheet.py
+++ b/utils/cheatsheet.py
@@ -45,7 +45,8 @@ env = jinja2.Environment(
     lstrip_blocks=True
 )
 
-# determines the order in which sections are displayed
+# determines the order in which sections are displayed,
+# final column indicates that a new page is inserted _after_ that section
 OPS_SECTIONS = [
     ("variables",     "Variables",     False),
     ("hardware",      "Hardware",      False),
@@ -61,9 +62,11 @@ OPS_SECTIONS = [
     ("whitewhale",    "Whitewhale",    False),
     ("meadowphysics", "Meadowphysics", False),
     ("earthsea",      "Earthsea",      False),
-    ("orca",          "Orca",          False),
-    ("justfriends",   "Just Friends",  True),
-    ("wslash",        "W/",            True),
+    ("orca",          "Orca",          True),
+    ("justfriends",   "Just Friends",  False),
+    ("wslash",        "W/",            False),
+    ("er301",         "ER-301",        False),
+    ("fader",         "Fader",         True),
     ("telex_i",       "TELEXi",        False),
     ("telex_o",       "TELEXo",        False)
 ]

--- a/utils/common/__init__.py
+++ b/utils/common/__init__.py
@@ -54,6 +54,7 @@ def _convert_struct_name_to_op_name(name):
         "SYM_STAR":               "*",
         "SYM_FORWARD_SLASH":      "/",
         "SYM_PERCENTAGE":         "%",
+        "SYM_DOLLAR":             "$",
         "SYM_EQUAL_x2":           "==",
         "SYM_EXCLAMATION_EQUAL":  "!=",
         "SYM_LEFT_ANGLED":        "<",

--- a/utils/docs.py
+++ b/utils/docs.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import jinja2
 import pypandoc
 import pytoml as toml
-import subprocess
 
 from common import list_ops, list_mods, validate_toml, get_tt_version
 
@@ -19,8 +18,9 @@ TEMPLATE_DIR = ROOT_DIR / "utils" / "templates"
 DOCS_DIR = ROOT_DIR / "docs"
 OP_DOCS_DIR = DOCS_DIR / "ops"
 FONTS_DIR = ROOT_DIR / "utils" / "fonts"
-_VERSION_ = get_tt_version()
-_VERSION_STR_ = "Teletype " + _VERSION_["tag"] + " " + _VERSION_["hash"] + " Documentation"
+TT_VERSION = get_tt_version()
+VERSION_STR = " ".join(["Teletype", TT_VERSION["tag"], TT_VERSION["hash"],
+                        "Documentation"])
 
 env = jinja2.Environment(
     autoescape=False,
@@ -75,8 +75,8 @@ def common_md():
     op_extended_template = env.get_template("op_extended.jinja2.md")
 
     output = ""
-    output += Path(DOCS_DIR / "intro.md").read_text() \
-                                         .replace("VERSION", _VERSION_["tag"][1:]) + "\n\n"
+    output += Path(DOCS_DIR / "intro.md") \
+        .read_text().replace("VERSION", TT_VERSION["tag"][1:]) + "\n\n"
     output += Path(DOCS_DIR / "whats_new.md").read_text() + "\n\n"
     output += Path(DOCS_DIR / "quickstart.md").read_text() + "\n\n"
     output += Path(DOCS_DIR / "keys.md").read_text() + "\n\n"
@@ -154,7 +154,7 @@ def main():
         if ext == ".md":
             p.write_text(output)
         elif ext == ".html":
-            output = "# " + _VERSION_STR_ + "\n\n" + output
+            output = "# " + VERSION_STR + "\n\n" + output
             pypandoc.convert_text(
                 output,
                 format=input_format,
@@ -165,11 +165,12 @@ def main():
                             "--toc",
                             "--toc-depth=2",
                             "--css=" + str(TEMPLATE_DIR / "docs.css"),
-                            "--template=" + str(TEMPLATE_DIR / "template.html5")])
+                            "--template=" + str(TEMPLATE_DIR /
+                                                "template.html5")])
         elif ext == ".pdf" or ext == ".tex":
             latex_preamble = env.get_template("latex_preamble.jinja2.md")
             latex = latex_preamble \
-            .render(title=_VERSION_STR_, fonts_dir=FONTS_DIR) + "\n\n"
+                .render(title=VERSION_STR, fonts_dir=FONTS_DIR) + "\n\n"
             latex += output
             pandoc_version = int(pypandoc.get_pandoc_version()[0])
             engine = ("--pdf-engine=xelatex"

--- a/utils/docs.py
+++ b/utils/docs.py
@@ -66,6 +66,7 @@ def deep_merge_dict(source, destination):
 
 
 def common_md():
+    print(f"Pandoc version:           {pypandoc.get_pandoc_version()}")
     print(f"Using docs directory:     {DOCS_DIR}")
     print(f"Using ops docs directory: {OP_DOCS_DIR}")
     print()
@@ -170,6 +171,10 @@ def main():
             latex = latex_preamble \
             .render(title=_VERSION_STR_, fonts_dir=FONTS_DIR) + "\n\n"
             latex += output
+            pandoc_version = int(pypandoc.get_pandoc_version()[0])
+            engine = ("--pdf-engine=xelatex"
+                      if pandoc_version >= 2
+                      else "--latex-engine=xelatex")
             pypandoc.convert_text(
                 latex,
                 format=input_format,
@@ -179,7 +184,7 @@ def main():
                             "--column=80",
                             "--toc",
                             "--toc-depth=2",
-                            "--latex-engine=xelatex",
+                            engine,
                             "--variable=papersize:A4"])
 
 

--- a/utils/templates/latex_preamble.jinja2.md
+++ b/utils/templates/latex_preamble.jinja2.md
@@ -21,6 +21,7 @@ header-includes:
 - \usepackage{titlesec}
 - \titleformat{\chapter}{\normalfont\LARGE\bfseries}{\thechapter.}{1em}{}
 - \titlespacing*{\chapter}{0pt}{3.5ex plus 1ex minus .2ex}{2.3ex plus .2ex}
+- \usepackage{etoolbox}
 - \AtBeginEnvironment{longtable}{\small}{}{}
 - \renewcommand\arraystretch{1.3}
 ---


### PR DESCRIPTION
#### What does this PR do?

Fixes for:
 - Pandoc >= 2.0
 - General Python tidying up (PEP8 formatting, etc)
 - Fixes a bug with `~` in the cheatsheet
 - Adds in the ER-301 and the fader bank OPs to the cheatsheet, as well as move the page breaks about

#### Provide links to any related discussion on [lines](https://llllllll.co/).

https://llllllll.co/t/teletype-docs-enhancements-docs-and-cheatsheet-live/8612/166?u=sam

#### How should this be manually tested?

Make the docs

```
cd docs
make
```

#### Any background context you want to provide?

I've tested it with Pandoc 1.19.2.4 and 2.1.2 on Archlinux. Let me know if you spot any regressions.


